### PR TITLE
fix nullptr exception

### DIFF
--- a/brightness.h
+++ b/brightness.h
@@ -211,7 +211,7 @@ char* getdeviceinfo() {
             //printf("  Interface:    %d\n", cur_dev->interface_number);
             //printf("\n");
 
-            if (wcsstr(cur_dev->product_string, L"BRIGHTNESS"))
+            if (cur_dev->product_string && wcsstr(cur_dev->product_string, L"BRIGHTNESS"))
             {
                 ultrafine_monitor_path = cur_dev->path;
                 break;


### PR DESCRIPTION
I have a `NULL` value for one of the `cur_dev->product_string` which causes this code to crash.

```
Unhandled Exception: System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at wcsstr(Char* , Char* )
   at getdeviceinfo()
   at LGUltrafineBrightness.mainForm..ctor()
   at main(String[] args)
   at mainCRTStartupStrArray(String[] arguments)
```